### PR TITLE
Add setObserver, GameStartEvent, GameEndEvent

### DIFF
--- a/lib/src/main/java/edu/brandeis/cosi/atg/engine/Engine.java
+++ b/lib/src/main/java/edu/brandeis/cosi/atg/engine/Engine.java
@@ -239,4 +239,16 @@ public interface Engine {
      *                                  decision
      */
     public GameResult play() throws PlayerViolationException;
+
+    /**
+     * Sets an additional observer to receive game events.
+     * <br/>
+     * This observer is notified alongside any player-specific observers.
+     * It can be used for logging, testing, or external monitoring.
+     *
+     * @param observer the observer to notify of game events
+     */
+    default void setObserver(GameObserver observer) {
+        // Default no-op; implementations should override to store and use the observer.
+    }
 }

--- a/lib/src/main/java/edu/brandeis/cosi/atg/event/Event.java
+++ b/lib/src/main/java/edu/brandeis/cosi/atg/event/Event.java
@@ -19,11 +19,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
                 @JsonSubTypes.Type(value = EndTurnEvent.class, name = "end_turn"),
                 @JsonSubTypes.Type(value = GainCardEvent.class, name = "gain_card"),
                 @JsonSubTypes.Type(value = GameEvent.class, name = "game"),
+                @JsonSubTypes.Type(value = GameStartEvent.class, name = "game_start"),
+                @JsonSubTypes.Type(value = GameEndEvent.class, name = "game_end"),
                 @JsonSubTypes.Type(value = PlayCardEvent.class, name = "play_card"),
                 @JsonSubTypes.Type(value = TrashCardEvent.class, name = "trash_card"),
 })
 public sealed interface Event
-                permits DiscardCardEvent, EndTurnEvent, GainCardEvent, GameEvent, PlayCardEvent, TrashCardEvent {
+                permits DiscardCardEvent, EndTurnEvent, GainCardEvent, GameEvent, GameStartEvent, GameEndEvent,
+                PlayCardEvent, TrashCardEvent {
 
         /**
          * Gets the description of the event.

--- a/lib/src/main/java/edu/brandeis/cosi/atg/event/GameEndEvent.java
+++ b/lib/src/main/java/edu/brandeis/cosi/atg/event/GameEndEvent.java
@@ -1,0 +1,31 @@
+package edu.brandeis.cosi.atg.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import edu.brandeis.cosi.atg.state.CardStacks;
+import edu.brandeis.cosi.atg.state.GameResult;
+
+/**
+ * Represents the end of a game.
+ *
+ * <p>Fired once at the end of {@link edu.brandeis.cosi.atg.engine.Engine#play()},
+ * after the final turn has completed and before the result is returned.
+ *
+ * @param finalSupply the card supply remaining at the end of the game
+ * @param result      the game result containing player scores and ending decks
+ */
+public record GameEndEvent(CardStacks finalSupply, GameResult result) implements Event {
+
+    /**
+     * Compact constructor that validates required fields are not null.
+     */
+    public GameEndEvent {
+        java.util.Objects.requireNonNull(finalSupply, "finalSupply must not be null");
+        java.util.Objects.requireNonNull(result, "result must not be null");
+    }
+
+    @Override
+    @JsonIgnore
+    public String getDescription() {
+        return "Game ended";
+    }
+}

--- a/lib/src/main/java/edu/brandeis/cosi/atg/event/GameStartEvent.java
+++ b/lib/src/main/java/edu/brandeis/cosi/atg/event/GameStartEvent.java
@@ -1,0 +1,31 @@
+package edu.brandeis.cosi.atg.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ImmutableList;
+import edu.brandeis.cosi.atg.state.CardStacks;
+
+/**
+ * Represents the start of a game.
+ *
+ * <p>Fired once at the beginning of {@link edu.brandeis.cosi.atg.engine.Engine#play()},
+ * after players have been dealt their starting hands and the supply has been initialized.
+ *
+ * @param playerNames   the names of the players in turn order
+ * @param initialSupply the initial card supply available for purchase
+ */
+public record GameStartEvent(ImmutableList<String> playerNames, CardStacks initialSupply) implements Event {
+
+    /**
+     * Compact constructor that validates required fields are not null.
+     */
+    public GameStartEvent {
+        java.util.Objects.requireNonNull(playerNames, "playerNames must not be null");
+        java.util.Objects.requireNonNull(initialSupply, "initialSupply must not be null");
+    }
+
+    @Override
+    @JsonIgnore
+    public String getDescription() {
+        return "Game started with players: " + String.join(", ", playerNames);
+    }
+}

--- a/lib/src/main/java/edu/brandeis/cosi/atg/event/package-info.java
+++ b/lib/src/main/java/edu/brandeis/cosi/atg/event/package-info.java
@@ -2,7 +2,7 @@
  * This package contains classes related to game events.
  * <br/>
  * <br/>
- * There are six types of events:
+ * There are eight types of events:
  * <ul>
  * <li>{@link PlayCardEvent} - an event that occurs when a card is played</li>
  * <li>{@link GainCardEvent} - an event that occurs when a card is gained</li>
@@ -13,6 +13,10 @@
  * (permanently removed from the player's deck)</li>
  * <li>{@link GameEvent} - a generic event which doesn't fit any of the other
  * categories</li>
+ * <li>{@link GameStartEvent} - fired once at the start of a game, with player
+ * names and initial supply</li>
+ * <li>{@link GameEndEvent} - fired once at the end of a game, with the final
+ * supply</li>
  * </ul>
  * <br/>
  * <br/>

--- a/lib/src/test/java/edu/brandeis/cosi/atg/api/TestJsonSerialization.java
+++ b/lib/src/test/java/edu/brandeis/cosi/atg/api/TestJsonSerialization.java
@@ -3,12 +3,15 @@ package edu.brandeis.cosi.atg.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import edu.brandeis.cosi.atg.state.CardStacks;
+import edu.brandeis.cosi.atg.state.GameResult;
 import edu.brandeis.cosi.atg.state.GameState;
 import edu.brandeis.cosi.atg.state.Hand;
-import edu.brandeis.cosi.atg.state.CardStacks;
+import edu.brandeis.cosi.atg.state.PlayerResult;
 import edu.brandeis.cosi.atg.cards.Card;
 import edu.brandeis.cosi.atg.decisions.BuyDecision;
 import edu.brandeis.cosi.atg.decisions.DiscardCardDecision;
@@ -19,7 +22,9 @@ import edu.brandeis.cosi.atg.decisions.TrashCardDecision;
 import edu.brandeis.cosi.atg.event.DiscardCardEvent;
 import edu.brandeis.cosi.atg.event.EndTurnEvent;
 import edu.brandeis.cosi.atg.event.GainCardEvent;
+import edu.brandeis.cosi.atg.event.GameEndEvent;
 import edu.brandeis.cosi.atg.event.GameEvent;
+import edu.brandeis.cosi.atg.event.GameStartEvent;
 import edu.brandeis.cosi.atg.event.PlayCardEvent;
 import edu.brandeis.cosi.atg.event.TrashCardEvent;
 
@@ -98,6 +103,25 @@ public class TestJsonSerialization {
     @Test
     public void testTrashCardDecisionSerialization() throws Exception {
         testJsonRoundTrip(new TrashCardDecision(new Card(Card.Type.FRAMEWORK, 5)));
+    }
+
+    @Test
+    public void testGameStartEventSerialization() throws Exception {
+        CardStacks supply = new CardStacks(ImmutableMap.of(
+                Card.Type.FRAMEWORK, 8,
+                Card.Type.BITCOIN, 60));
+        testJsonRoundTrip(new GameStartEvent(ImmutableList.of("Alice", "Bob"), supply));
+    }
+
+    @Test
+    public void testGameEndEventSerialization() throws Exception {
+        CardStacks finalSupply = new CardStacks(ImmutableMap.of(
+                Card.Type.FRAMEWORK, 0,
+                Card.Type.BITCOIN, 42));
+        GameResult result = new GameResult(ImmutableList.of(
+                new PlayerResult("Alice", 12, ImmutableList.of(new Card(Card.Type.FRAMEWORK, 1))),
+                new PlayerResult("Bob", 8, ImmutableList.of(new Card(Card.Type.MODULE, 2)))));
+        testJsonRoundTrip(new GameEndEvent(finalSupply, result));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add `default void setObserver(GameObserver)` to `Engine` interface — enables external observers for testing/logging
- Add `GameStartEvent(playerNames, initialSupply)` — fired once at game start
- Add `GameEndEvent(finalSupply)` — fired once at game end
- Update sealed `Event` permits clause and Jackson `@JsonSubTypes`
- Update package-info.java

These support the engine verifier harness for validating student Engine implementations.

## Test plan
- [x] All 15 existing tests pass
- [ ] Verify Jackson serialization round-trips for new event types

🤖 Generated with [Claude Code](https://claude.com/claude-code)